### PR TITLE
bin/find_m4.sh: rework to handle ignoring comments

### DIFF
--- a/bin/find_m4.sh
+++ b/bin/find_m4.sh
@@ -390,6 +390,9 @@ EOF
 
           ewarn "diff using:\n     git diff --no-index <(git -C "${expected_repository}" show "${expected_gitcommit}":${common_stem}) "${file}""
           eoutdent
+
+          # No point in checking this one against other checksums
+          break
         fi
       fi
     done

--- a/bin/find_m4.sh
+++ b/bin/find_m4.sh
@@ -128,7 +128,7 @@ get_common_stem()
   # Sometimes, we might have completely disjoint paths apart from the filename.
   # In that case, take the repo path and just append the path to it relative to the repo.
   if [[ ${common_stem} == "${filename}" ]] ; then
-    common_stem=${strip_prefix##"${path_b}"}
+    common_stem=${path_a##"${strip_prefix}"}
     common_stem=${common_stem#/}
   fi
   echo "${common_stem}"

--- a/bin/find_m4.sh
+++ b/bin/find_m4.sh
@@ -158,7 +158,7 @@ populate_db()
 
     # Get the file without any comments on a best-effort basis
     checksum_type=1
-    stripped_contents=$(gawk '/changecom/{exit 1}; { gsub(/#.*/,""); gsub(/^dnl.*/,""); print}' "${file}" 2>/dev/null)
+    stripped_contents=$(gawk '/changecom/{exit 1}; { gsub(/#.*/,""); gsub(/(^| )dnl.*/,""); print}' "${file}" 2>/dev/null)
     ret=$?
     if [[ ${ret} -eq 1 ]] ; then
       # The file contained 'changecom', so we have to do the best we can.


### PR DESCRIPTION
* Record checksumtype to indicate if it's a comment-stripped checksum or not
* Factor out get_common_stem into its own function
* Use get_common_stem and emit a diff cmd for new serial numbers to ease comparison