### PR TITLE
Revert "bin/find_m4.sh: deduplicate diff commands"

### DIFF
--- a/bin/find_m4.sh
+++ b/bin/find_m4.sh
@@ -402,7 +402,7 @@ EOF
         expected_gitpath=${parsed_results[7]}
         verbose ${cmd} "diff using:"$'\n\t'"git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}'"
 
-        DIFF_CMDS[${strip_checksum}]="git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}' # discontinuity"
+        DIFF_CMDS+=( "git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}' # discontinuity" )
         # We don't want to emit loads of diff commands for the same thing
         bad_checksums[${plain_checksum}]=1
         bad_checksums[${strip_checksum}]=1
@@ -495,7 +495,7 @@ EOF
 			        "${expected_strip_checksum}" "${strip_checksum}")" \
 		        "diff using:"$'\n\t'"git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}'"
 
-          DIFF_CMDS[${strip_checksum}]="git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}' # mismatch"
+          DIFF_CMDS+=( "git diff --no-index <(git -C ${expected_repository} show '${expected_gitcommit}:${expected_gitpath}') '${file}' # mismatch" )
 
           # We don't want to emit loads of diff commands for the same thing
           bad_checksums[${plain_checksum}]=1
@@ -519,13 +519,14 @@ done
 # MODE=1: search against the db
 : "${MODE:=0}"
 
-declare -Ag NEW_MACROS=() DIFF_CMDS=()
+declare -Ag NEW_MACROS=()
 
 M4_FILES=()
 NEW_MACROS=()
 NEW_SERIAL_MACROS=()
 BAD_MACROS=()
 BAD_SERIAL_MACROS=()
+DIFF_CMDS=()
 MATCH_COUNT=0
 
 if [[ ${MODE} == 0 ]] ; then
@@ -592,7 +593,7 @@ else
 		eerror "Significant serial diff. macros: ${_sorted[@]}"
 
     # DIFF_CMDS is already in a logical order (grouped by project)
-    (( ${#DIFF_CMDS[@]} > 0 )) && {
+    (( ${#DIFF_CMDS} > 0 )) && {
       eerror "Collected diff cmds for review:" ;
       printf "%s\n" "${DIFF_CMDS[@]}" ;
     }


### PR DESCRIPTION
This reverts commit 7d794f14131af24433156ce0bd985d1a5aa766f1.

We already deduplicate by punting in `compare_with_db` populating `bad_checksums` when a checksum is bad, and then returning early on line ~412 within the max_serial_seen_query check.